### PR TITLE
Feature/add-friend_editText 포커스 아웃 시 키보드 hide 추가

### DIFF
--- a/app/src/main/java/org/seemeet/seemeet/ui/friend/AddFriendActivity.kt
+++ b/app/src/main/java/org/seemeet/seemeet/ui/friend/AddFriendActivity.kt
@@ -1,7 +1,10 @@
 package org.seemeet.seemeet.ui.friend
 
+import android.graphics.Rect
 import android.os.Bundle
+import android.view.MotionEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
@@ -22,6 +25,23 @@ class AddFriendActivity : AppCompatActivity() {
         viewModel.returnAddFriendList()
 
         initClickListener()
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        val focusView = currentFocus
+        if (focusView != null && ev != null) {
+            val rect = Rect()
+            focusView.getGlobalVisibleRect(rect)
+            val x = ev.x.toInt()
+            val y = ev.y.toInt()
+
+            if (!rect.contains(x, y)) {
+                val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                imm?.hideSoftInputFromWindow(focusView.windowToken, 0)
+                focusView.clearFocus()
+            }
+        }
+        return super.dispatchTouchEvent(ev)
     }
 
     private fun initClickListener() {

--- a/app/src/main/java/org/seemeet/seemeet/ui/friend/FriendActivity.kt
+++ b/app/src/main/java/org/seemeet/seemeet/ui/friend/FriendActivity.kt
@@ -2,8 +2,11 @@ package org.seemeet.seemeet.ui.friend
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
+import android.view.MotionEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
@@ -27,6 +30,23 @@ class FriendActivity : AppCompatActivity() {
         setFriendAdapter()
         setFriendObserver()
         initClickListener()
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        val focusView = currentFocus
+        if (focusView != null && ev != null) {
+            val rect = Rect()
+            focusView.getGlobalVisibleRect(rect)
+            val x = ev.x.toInt()
+            val y = ev.y.toInt()
+
+            if (!rect.contains(x, y)) {
+                val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                imm?.hideSoftInputFromWindow(focusView.windowToken, 0)
+                focusView.clearFocus()
+            }
+        }
+        return super.dispatchTouchEvent(ev)
     }
 
     // 어댑터
@@ -73,6 +93,8 @@ class FriendActivity : AppCompatActivity() {
             friendAdapter.setSearchWord(binding.etSearchFriend.text.toString())
         }
     }
+
+
 
     companion object {
         fun start(context: Context) {

--- a/app/src/main/res/layout/activity_add_friend.xml
+++ b/app/src/main/res/layout/activity_add_friend.xml
@@ -78,6 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/ic_btn_remove"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/et_search_friend_id"
             app:layout_constraintEnd_toEndOf="@+id/et_search_friend_id"
             app:layout_constraintTop_toTopOf="@+id/et_search_friend_id" />

--- a/app/src/main/res/layout/activity_friend.xml
+++ b/app/src/main/res/layout/activity_friend.xml
@@ -82,6 +82,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/ic_btn_remove"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/et_search_friend"
             app:layout_constraintEnd_toEndOf="@+id/et_search_friend"
             app:layout_constraintTop_toTopOf="@+id/et_search_friend" />


### PR DESCRIPTION
editText 포커스 아웃일 때 키보드 내려가게 하는 코드 추가했습니다.
입력창 있는 다른 뷰에도 적용하시려면 해당 editText 있는 activity에서 아래 코드 추가하시면 됩니다.
제가 쓴 코드가 아니라서 혹시 리팩토링 가능한 부분 있으면 알려주세요 (속닥)
</br>
```
    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
        val focusView = currentFocus
        if (focusView != null && ev != null) {
            val rect = Rect()
            focusView.getGlobalVisibleRect(rect)
            val x = ev.x.toInt()
            val y = ev.y.toInt()

            if (!rect.contains(x, y)) {
                val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
                imm?.hideSoftInputFromWindow(focusView.windowToken, 0)
                focusView.clearFocus()
            }
        }
        return super.dispatchTouchEvent(ev)
    }
```