### PR TITLE
[FEAT] login api 연동 (error message 분기처리 수정 필요)

### DIFF
--- a/app/src/main/java/org/seemeet/seemeet/data/api/LoginService.kt
+++ b/app/src/main/java/org/seemeet/seemeet/data/api/LoginService.kt
@@ -1,0 +1,17 @@
+package org.seemeet.seemeet.data.api
+
+import org.seemeet.seemeet.data.model.request.login.RequestLoginList
+import org.seemeet.seemeet.data.model.response.login.ResponseLoginList
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+interface LoginService {
+    @Headers("Content-Type:application/json")
+    @POST("auth/login")
+    fun postLogin(
+        @Body body : RequestLoginList
+    ): Call<ResponseLoginList>
+}

--- a/app/src/main/java/org/seemeet/seemeet/data/api/RetrofitBuilder.kt
+++ b/app/src/main/java/org/seemeet/seemeet/data/api/RetrofitBuilder.kt
@@ -14,5 +14,5 @@ object RetrofitBuilder {
     val planService: PlanService = seeMeetRetrofit.create(PlanService::class.java)
     val friendService: FriendService = seeMeetRetrofit.create(FriendService::class.java)
     val invitationService : InvitationService = seeMeetRetrofit.create(InvitationService::class.java)
-
+    val loginService : LoginService = seeMeetRetrofit.create(LoginService::class.java)
 }

--- a/app/src/main/java/org/seemeet/seemeet/data/model/request/login/RequestLoginList.kt
+++ b/app/src/main/java/org/seemeet/seemeet/data/model/request/login/RequestLoginList.kt
@@ -1,0 +1,6 @@
+package org.seemeet.seemeet.data.model.request.login
+
+data class RequestLoginList(
+    val email : String,
+    val password : String
+)

--- a/app/src/main/java/org/seemeet/seemeet/data/model/response/login/ResponseError.kt
+++ b/app/src/main/java/org/seemeet/seemeet/data/model/response/login/ResponseError.kt
@@ -1,0 +1,8 @@
+package org.seemeet.seemeet.data.model.response.login
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseError(
+    @SerializedName("errorCode") val errorCode: Int,
+    @SerializedName("errorMessage") val errorMessage: String
+)

--- a/app/src/main/java/org/seemeet/seemeet/data/model/response/login/ResponseLoginList.kt
+++ b/app/src/main/java/org/seemeet/seemeet/data/model/response/login/ResponseLoginList.kt
@@ -1,0 +1,28 @@
+package org.seemeet.seemeet.data.model.response.login
+
+import java.util.*
+
+data class ResponseLoginList(
+    val status: Int,
+    val success: Boolean,
+    val message: String,
+    val data: Data
+)
+
+data class UserInfo(
+    val id: Int,
+    val email: String,
+    val idFirebase: String,
+    val username: String,
+    val gender: String,
+    val birth: Date,
+    val isNoticed: Boolean,
+    val createdAt: Date,
+    val updatedAt: Date,
+    val isDeleted: Boolean
+)
+
+data class Data(
+    val user: UserInfo,
+    val accesstoken: String
+)

--- a/app/src/main/java/org/seemeet/seemeet/ui/registration/LoginActivity.kt
+++ b/app/src/main/java/org/seemeet/seemeet/ui/registration/LoginActivity.kt
@@ -5,14 +5,21 @@ import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
 import android.text.method.PasswordTransformationMethod
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import org.seemeet.seemeet.R
+import org.seemeet.seemeet.data.api.RetrofitBuilder
+import org.seemeet.seemeet.data.model.request.login.RequestLoginList
+import org.seemeet.seemeet.data.model.response.login.ResponseLoginList
 import org.seemeet.seemeet.databinding.ActivityLoginBinding
 import org.seemeet.seemeet.ui.main.MainActivity
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 
 class LoginActivity : AppCompatActivity() {
@@ -50,17 +57,44 @@ class LoginActivity : AppCompatActivity() {
         }
     }
 
-    fun initClickListener() {
-        binding.btnLogin.setOnClickListener {
-            if (!binding.etEmail.text.toString().equals("hi@nate.com")) { //아이디 틀렸을 때
-                CustomToast.createToast(this, "등록되지 않은 유저입니다.")?.show()
-            } else { //아이디는 맞음
-                if (!binding.etPw.text.toString().equals("1234567i")) {
-                    CustomToast.createToast(this, "비밀번호가 틀렸습니다.")?.show()
-                } else { //비밀번호까지 다 맞을 때
-                    MainActivity.start(this)
+    fun initNetwork() {
+        val requestLoginData = RequestLoginList(
+            email = binding.etEmail.text.toString(),
+            password = binding.etPw.text.toString()
+        )
+        val call: Call<ResponseLoginList> = RetrofitBuilder.loginService.postLogin(requestLoginData)
+
+        call.enqueue(object : Callback<ResponseLoginList> {
+            override fun onResponse(
+                call: Call<ResponseLoginList>,
+                response: Response<ResponseLoginList>
+            ) {
+                if (response.isSuccessful) {
+                    MainActivity.start(this@LoginActivity)
+                    Log.d("testt", response.body().toString())
+                } else {
+                    CustomToast.createToast(this@LoginActivity, "올바르지 않은 정보입니다.")?.show()
+                    /*
+                        Log.d("**errorbody", response.toString())
+
+                        if(response.code().toString().equals("404")){
+                            //유저 없을 때
+                            CustomToast.createToast(this@LoginActivity, "등록되지 않은 유저입니다.")?.show()
+                        }else if(response.code().toString().equals("403")){
+                            CustomToast.createToast(this@LoginActivity, "비밀번호가 틀렸습니다.")?.show()
+                        }*/
                 }
             }
+
+            override fun onFailure(call: Call<ResponseLoginList>, t: Throwable) {
+                Log.e("NetWorkTest", "error:$t")
+            }
+        })
+    }
+
+    fun initClickListener() {
+        binding.btnLogin.setOnClickListener {
+            initNetwork()
         }
         binding.tvRegister.setOnClickListener {
             val nextIntent = Intent(this, RegisterActivity::class.java)


### PR DESCRIPTION
+) 추가해야할 것

- [ ] 아이디 틀렸을 때, 비밀번호 틀렸을 때, 이메일 형식일 때 토스트 내용 다르게 띄우기
- [ ] https://jungwoon.github.io/android/2020/04/25/Retrofit-ErrorResponseHandling.html -> 링크 참조