### PR TITLE
[FIX] 친구 목록 이름 정렬 수정

### DIFF
--- a/app/src/main/java/org/seemeet/seemeet/ui/friend/FriendActivity.kt
+++ b/app/src/main/java/org/seemeet/seemeet/ui/friend/FriendActivity.kt
@@ -58,7 +58,6 @@ class FriendActivity : AppCompatActivity() {
         viewModel.friendList.observe(this, Observer { friendList ->
             with(binding.rvFriend.adapter as FriendListAdapter) {
                 setFriendList(friendList.data)
-
                 if (friendList.data.isEmpty()) {
                     setVisibility(binding.clFriendNull, View.VISIBLE)
                 } else {

--- a/app/src/main/java/org/seemeet/seemeet/ui/friend/adapter/FriendListAdapter.kt
+++ b/app/src/main/java/org/seemeet/seemeet/ui/friend/adapter/FriendListAdapter.kt
@@ -58,7 +58,7 @@ class FriendListAdapter : RecyclerView.Adapter<FriendListAdapter.FriendViewHolde
     }
 
     fun setFriendList(friendList: List<FriendListData>) {
-        this.friendList = friendList
+        this.friendList = friendList.sortedWith(compareBy{it.username})
         notifyDataSetChanged()
     }
 }


### PR DESCRIPTION
친구 목록 뷰에서 두 글자 이름, 영어 이름까지 정렬되도록 한번 더 sorting 했습니다.