### PR TITLE
[FIX] buildConfigField

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 
-        buildConfigField ("String", "KAKAO_APP_KEY", properties.get('KAKAO_APP_KEY'))
+        buildConfigField ("String", "KAKAO_APP_KEY", "\"${properties.get('KAKAO_APP_KEY')}\"")
         manifestPlaceholders = [KAKAO_APP_KEY: properties.get('KAKAO_APP_KEY')]
     }
 


### PR DESCRIPTION
메니페스트에 kakaoLogin Redirect URI 관련하여 buildConfigField 수정하였습니다.
해당 브랜치 머지하고나서는 로컬 프로퍼티에 있는 KAKAO_APP_KEY에 있는 값에서 큰따옴표 빼주시면 됩니다.